### PR TITLE
Fix menu link to resume relative to home

### DIFF
--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -3,7 +3,7 @@ main:
   url: /
   weight: 10
 - name: Resume
-  url: "george_kousis_resume.pdf"
+  url: "/george_kousis_resume.pdf"
   weight: 20
 # - name: About
 #   url: /about/


### PR DESCRIPTION
If clicked resume while on a page other than home, the url would be relative and file could not be found